### PR TITLE
add spatial type in mysql srctype

### DIFF
--- a/web/web.go
+++ b/web/web.go
@@ -1149,7 +1149,7 @@ func addTypeToList(convertedType string, spType string, issues []internal.Schema
 }
 func init() {
 	// Initialize mysqlTypeMap.
-	for _, srcType := range []string{"bool", "boolean", "varchar", "char", "text", "tinytext", "mediumtext", "longtext", "set", "enum", "json", "bit", "binary", "varbinary", "blob", "tinyblob", "mediumblob", "longblob", "tinyint", "smallint", "mediumint", "int", "integer", "bigint", "double", "float", "numeric", "decimal", "date", "datetime", "timestamp", "time", "year"} {
+	for _, srcType := range []string{"bool", "boolean", "varchar", "char", "text", "tinytext", "mediumtext", "longtext", "set", "enum", "json", "bit", "binary", "varbinary", "blob", "tinyblob", "mediumblob", "longblob", "tinyint", "smallint", "mediumint", "int", "integer", "bigint", "double", "float", "numeric", "decimal", "date", "datetime", "timestamp", "time", "year", "geometrycollection", "multipoint", "multilinestring", "multipolygon", "point", "linestring", "polygon", "geometry"} {
 		var l []typeIssue
 		for _, spType := range []string{ddl.Bool, ddl.Bytes, ddl.Date, ddl.Float64, ddl.Int64, ddl.String, ddl.Timestamp, ddl.Numeric} {
 			ty, issues := toSpannerTypeMySQL(srcType, spType, []int64{})


### PR DESCRIPTION
Bug Fix #192
Two input methods to convert

Method 1
give the path of the SQL dump file.

Method 2
direct connect with a local database.

Spatial type is not added in MySQL source type array, this pr will add those type.